### PR TITLE
regex for block tags fixed to include h1-h6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 vendor/
 report/
 composer.lock

--- a/src/Indenter.php
+++ b/src/Indenter.php
@@ -93,7 +93,7 @@ class Indenter {
 
             $patterns = array(
                 // block tag
-                '/^(<([a-z]+)(?:[^>]*)>(?:[^<]*)<\/(?:\2)>)/' => static::MATCH_INDENT_NO,
+                '/^(<([a-z|h1-6]+)(?:[^>]*)>(?:[^<]*)<\/(?:\2)>)/' => static::MATCH_INDENT_NO,
                 // DOCTYPE
                 '/^<!([^>]*)>/' => static::MATCH_INDENT_NO,
                 // tag with implied closing


### PR DESCRIPTION
Added support for heading tags to be matched as block tags. Headings were matched against regex for open and close tags so content inside was pushed to new line. This isn't a big deal, but for our project we needed it to be placed inside one line.