### PR TITLE
Feat inlinesvg

### DIFF
--- a/src/Indenter.php
+++ b/src/Indenter.php
@@ -97,9 +97,9 @@ class Indenter {
                 // DOCTYPE
                 '/^<!([^>]*)>/' => static::MATCH_INDENT_NO,
                 // tag with implied closing
-				'/^<(input|link|meta|base|br|img|source|hr)([^>]*)>/' => static::MATCH_INDENT_NO,
-				// self closing SVG tags
-				'/^<(animate|stop|path|circle|line|polyline|rect|use)([^>]*)\/>/' => static::MATCH_INDENT_NO,
+                '/^<(input|link|meta|base|br|img|source|hr)([^>]*)>/' => static::MATCH_INDENT_NO,
+                // self closing SVG tags
+                '/^<(animate|stop|path|circle|line|polyline|rect|use)([^>]*)\/>/' => static::MATCH_INDENT_NO,
                 // opening tag
                 '/^<[^\/]([^>]*)>/' => static::MATCH_INDENT_INCREASE,
                 // closing tag

--- a/src/Indenter.php
+++ b/src/Indenter.php
@@ -97,7 +97,9 @@ class Indenter {
                 // DOCTYPE
                 '/^<!([^>]*)>/' => static::MATCH_INDENT_NO,
                 // tag with implied closing
-                '/^<(input|link|meta|base|br|img|source|hr)([^>]*)>/' => static::MATCH_INDENT_NO,
+				'/^<(input|link|meta|base|br|img|source|hr)([^>]*)>/' => static::MATCH_INDENT_NO,
+				// self closing SVG tags
+				'/^<(animate|stop|path|circle|line|polyline|rect|use)([^>]*)\/>/' => static::MATCH_INDENT_NO,
                 // opening tag
                 '/^<[^\/]([^>]*)>/' => static::MATCH_INDENT_INCREASE,
                 // closing tag

--- a/tests/sample/input/5-inline-svg.html
+++ b/tests/sample/input/5-inline-svg.html
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1"> <rect x="25" y="25" width="200" height="200" fill="lime" stroke-width="4" stroke="pink" /><circle cx="125" cy="125" r="75" fill="orange" />
+  <polyline points="50,150 50,200 200,200 200,100" stroke="red" stroke-width="4" fill="none" />
+				<line x1="50" y1="50" x2="200" y2="200" stroke="blue" stroke-width="4" />
+</svg>

--- a/tests/sample/output/5-inline-svg.html
+++ b/tests/sample/output/5-inline-svg.html
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1">
+    <rect x="25" y="25" width="200" height="200" fill="lime" stroke-width="4" stroke="pink" />
+    <circle cx="125" cy="125" r="75" fill="orange" />
+    <polyline points="50,150 50,200 200,200 200,100" stroke="red" stroke-width="4" fill="none" />
+    <line x1="50" y1="50" x2="200" y2="200" stroke="blue" stroke-width="4" />
+</svg>


### PR DESCRIPTION
SVG elements need to be explicitly closed with a slash `<path />`. `<path></path>` is also valid, but would be catched by the genreal matching for tags.

For the moment I only added the `svg` elements I stumbled upon.

See #21