### PR TITLE
Use local phpunit to mitigate problems with different php versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_script:
   - mkdir -p build/logs
 
 script:
-  - phpunit --verbose --coverage-clover build/logs/clover.xml
+  - vendor/bin/phpunit --verbose --coverage-clover build/logs/clover.xml
 
 after_success:
   - php vendor/bin/coveralls -v

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 		"ext-mbstring": "*"
 	},
 	"require-dev": {
-	    "satooshi/php-coveralls": "dev-master"
+		"php-coveralls/php-coveralls": "^2.1.0"
 	},
 	"autoload": {
 		"psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
 		"ext-mbstring": "*"
 	},
 	"require-dev": {
-		"php-coveralls/php-coveralls": "^2.1.0"
+		"php-coveralls/php-coveralls": "^2.1.0",
+		"phpunit/phpunit": "4.*"
 	},
 	"autoload": {
 		"psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 		"ext-mbstring": "*"
 	},
 	"require-dev": {
-		"php-coveralls/php-coveralls": "^2.1.0",
+		"php-coveralls/php-coveralls": "^1.1.0",
 		"phpunit/phpunit": "4.*"
 	},
 	"autoload": {


### PR DESCRIPTION
Use local phpunit installation as suggested in pullrequest #17.
I've also switched from [satooshi/php-coveralls](https://packagist.org/packages/satooshi/php-coveralls) to [php-coveralls/php-coveralls](https://packagist.org/packages/php-coveralls/php-coveralls) due to the deprecation of [satooshi/php-coveralls](https://packagist.org/packages/satooshi/php-coveralls)