### PR TITLE
Fixed an issue with nesting inline tags breaking line (Issue #24)

### DIFF
--- a/tests/IndenterTest.php
+++ b/tests/IndenterTest.php
@@ -36,6 +36,17 @@ class IndenterTest extends PHPUnit_Framework_TestCase {
         $this->assertSame($expected_output, str_replace("\n", '', $indented));
     }
 
+
+    public function testIndentNestedInlineTags () {
+        $indenter = new \Gajus\Dindent\Indenter();
+
+        $indented = $indenter->indent('<span><strong><sup><a>foo</a></sup></strong></span>');
+
+        $expected_output = '<span><strong><sup><a>foo</a></sup></strong></span>';
+
+        $this->assertSame($expected_output, $indented);
+    }
+
     /**
      * @dataProvider logProvider
      */


### PR DESCRIPTION
Made a fix that allows nested inline tags to not get a line break. Outlined in Issue #24 . 